### PR TITLE
use getObject instead of getValue to access frame variables

### DIFF
--- a/src/som/interpreter/nodes/LocalVariableNode.java
+++ b/src/som/interpreter/nodes/LocalVariableNode.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.frame.FrameUtil;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 
@@ -63,7 +64,7 @@ public abstract class LocalVariableNode extends ExpressionNode {
     @Specialization // @Generic
     public Object doGeneric(final VirtualFrame frame) {
       assert isInitialized();
-      return frame.getValue(slot);
+      return FrameUtil.getObjectSafe(frame, slot);
     }
 
     protected final boolean isInitialized() {

--- a/src/som/interpreter/nodes/NonLocalVariableNode.java
+++ b/src/som/interpreter/nodes/NonLocalVariableNode.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.frame.FrameUtil;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 
@@ -55,7 +56,7 @@ public abstract class NonLocalVariableNode extends ContextualNode {
     @Specialization //@Generic
     public Object doGeneric(final VirtualFrame frame) {
       assert isInitialized();
-      return determineContext(frame).getValue(slot);
+      return FrameUtil.getObjectSafe(determineContext(frame), slot);
     }
 
     protected final boolean isInitialized() {

--- a/src/som/interpreter/nodes/ReturnNonLocalNode.java
+++ b/src/som/interpreter/nodes/ReturnNonLocalNode.java
@@ -83,7 +83,7 @@ public final class ReturnNonLocalNode extends ContextualNode {
     } else {
       blockEscaped.enter();
       SBlock block = (SBlock) FrameUtil.getObjectSafe(frame, localSelf);
-      Object self = ctx.getValue(outerSelfSlot);
+      Object self = FrameUtil.getObjectSafe(ctx, outerSelfSlot);
       return SAbstractObject.sendEscapedBlock(self, block, universe, frame.pack());
     }
   }

--- a/src/som/vmobjects/SBlock.java
+++ b/src/som/vmobjects/SBlock.java
@@ -33,6 +33,7 @@ import som.vm.Universe;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameUtil;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 
 public class SBlock extends SAbstractObject {
@@ -54,7 +55,7 @@ public class SBlock extends SAbstractObject {
   }
 
   public Object getOuterSelf() {
-    return getContext().getValue(outerSelfSlot);
+    return FrameUtil.getObjectSafe(getContext(), outerSelfSlot);
   }
 
   public static SMethod getEvaluationPrimitive(final int numberOfArguments,


### PR DESCRIPTION
Since you set only Object values, you should use the more efficient getObject to retrieve them. If you want to have primitive types as well, you should specialize reads and use the correspending typed getters.
